### PR TITLE
I'm just a bird

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,7 @@ jobs:
         uses: jwalton/gh-find-current-pr@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          state: closed
 
       - name: Determine Version Bump Level
         id: get_level
@@ -146,13 +147,3 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           script: |
             sudo systemctl restart bongbot
-
-  scan:
-    needs: deploy
-    runs-on: ubuntu-latest
-    steps:
-      - name: Scan Docker image
-        uses: docker/scan-action@v0
-        with:
-          image: ${{ secrets.DOCKERHUB_USERNAME }}/bongbot:latest
-          fail-on-finding: '{"critical": 1}'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,69 @@
+# .github/workflows/security-scan.yml
+name: Security Scan
+
+on:
+  # Run weekly on Mondays at 9 AM UTC
+  schedule:
+    - cron: '0 9 * * 1'
+  
+  # Allow manual triggering
+  workflow_dispatch:
+  
+  # Also run on pushes to main (for immediate feedback)
+  push:
+    branches: [ main ]
+  
+  # Run on pull requests to catch issues early
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v5
+
+      - name: Run Trivy vulnerability scanner on repository
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'sarif'
+          output: 'trivy-repo-results.sarif'
+
+      - name: Upload repository scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-repo-results.sarif'
+          category: 'repository-scan'
+
+  docker-scan:
+    runs-on: ubuntu-latest
+    # Only run if we're on main branch (where the latest Docker image exists)
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    steps:
+      - name: Run Trivy vulnerability scanner on Docker image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ secrets.DOCKERHUB_USERNAME }}/bongbot:latest
+          format: 'sarif'
+          output: 'trivy-docker-results.sarif'
+
+      - name: Upload Docker scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-docker-results.sarif'
+          category: 'docker-scan'


### PR DESCRIPTION
This pull request makes significant improvements to the project's security scanning workflow by replacing the previous inline Docker scan in the deployment workflow with a dedicated, more comprehensive security scanning workflow. The new setup uses Trivy for both repository and Docker image scans, and uploads results to GitHub's Security tab for better visibility. Additionally, a minor configuration adjustment was made to the deployment workflow.

**Security scanning improvements:**

* Introduced a new workflow file, `.github/workflows/security-scan.yml`, that runs Trivy vulnerability scans on both the repository and the Docker image, with results uploaded to GitHub's Security tab. This workflow is triggered on a schedule, on pushes to `main`, and on pull requests to `main`.

* Removed the previous Docker image scan job from `.github/workflows/deploy.yml`, consolidating all security scanning into the new workflow for better separation of concerns and maintainability.

**Deployment workflow adjustment:**

* Added the `state: closed` parameter to the `gh-find-current-pr` step in `.github/workflows/deploy.yml` to improve PR detection during deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Introduced automated security scans for the codebase and Docker image, running on schedule and for changes to the main branch and pull requests. Results appear in the repository’s Security tab.
  - Streamlined the deployment workflow by removing image scanning from the deploy process, improving release efficiency.
  - Updated pull request detection in workflows to also consider closed pull requests.
  - Minor formatting tidy-up with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->