### PR TITLE
Quomodo cecidisti de caelo Lucifer qui mane oriebaris.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
           if [[ -n "$pr_number" ]]; then
             echo "Found merged PR #$pr_number"
             # Get PR labels
-            labels=$(gh pr view $pr_number --json labels --jq '[.labels[].name] | join(",")')
+            labels=$(gh pr view $pr_number --json labels --jq '(.labels // []) | map(.name) | join(",")')
             echo "PR labels: $labels"
             echo "number=$pr_number" >> $GITHUB_OUTPUT
             echo "labels=$labels" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request updates the deployment workflow to improve how pull request information is retrieved and used for version bump determination. The main change is replacing the third-party GitHub Action with a custom shell script that finds the merged pull request for the current commit and extracts its labels, making the workflow more robust and flexible.

**Workflow improvements:**

* Replaced the `jwalton/gh-find-current-pr@v1` action with a custom shell script using the GitHub CLI (`gh`) to find the merged pull request for the current commit and retrieve its labels, which are then set as outputs for use in subsequent steps.

**Version bump logic enhancements:**

* Updated the version bump determination step to use the PR labels output directly, and switched to shell string matching (e.g., `[[ "$PR_LABELS" == *"major"* ]]`) for more reliable label checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None. No user-facing changes in this release.

- Chores
  - Streamlined release workflow to more reliably detect the associated pull request and its labels.
  - Simplified version bump evaluation based on labels, reducing parsing complexity.
  - Improved deployment logs for clearer visibility into detected labels and version bump decisions.

- Documentation
  - Updated internal release process notes to reflect the new label handling and evaluation approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->