### PR TITLE
Update QuoteDB API to interact with servers for server-specific quote handling

### DIFF
--- a/src/commands/quotedb_get.ts
+++ b/src/commands/quotedb_get.ts
@@ -1,32 +1,16 @@
 import { SlashCommandBuilder, ChatInputCommandInteraction, Client } from 'discord.js';
 import QuoteBuilder from '../helpers/quoteBuilder.js';
-import { apis } from '../config/index.js';
-import CALLER from '../helpers/caller.js';
 import { buildError } from '../helpers/errorBuilder.js';
-
-const API = apis.quotedb;
 
 export default {
     data: new SlashCommandBuilder()
         .setName('get_quotes')
         .setDescription('Get up to 5 recent quotes!')
-        .addIntegerOption(option => option.setName('number').setDescription('How many quotes do you want?').setRequired(false)),
+        .addIntegerOption(option => option.setName('number').setDescription('How many quotes do you want?').setRequired(false))
+        .addBooleanOption(option => option.setName('server').setDescription('Get quotes from this server only? Default: true').setRequired(false)),
     async execute(interaction: ChatInputCommandInteraction, client: Client) {
         try {
-            const number = interaction.options.getInteger('number') ?? 1;
-            if (number > 5) return await buildError(interaction, new Error("You can only request up to 5 quotes at a time."));
-
-            const response = await CALLER.get(
-                API.url,
-                `/api/v1/quotes/search/user/${API.user_id}`,
-                `max_quotes=${number}`,
-                { 'Content-Type': 'application/json', 'Authorization': `Bearer ${API.apikey}` },
-            );
-            if (response?.quotes?.length === 0) return await buildError(interaction, new Error("No quotes found."));
-            return new QuoteBuilder()
-                .setTitle('Recent Quotes')
-                .addQuotes(response.quotes)
-                .build(client);
+            return new QuoteBuilder().getQuote('/api/v1/quotes/search', 'Recent Quotes', client, interaction);
         } catch (error) {
             return await buildError(interaction, error);
         }

--- a/src/commands/quotedb_get.ts
+++ b/src/commands/quotedb_get.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction, Client } from 'discord.js';
+import { SlashCommandBuilder, ChatInputCommandInteraction, Client, InteractionContextType  } from 'discord.js';
 import QuoteBuilder from '../helpers/quoteBuilder.js';
 import { buildError } from '../helpers/errorBuilder.js';
 
@@ -7,7 +7,8 @@ export default {
         .setName('get_quotes')
         .setDescription('Get up to 5 recent quotes!')
         .addIntegerOption(option => option.setName('number').setDescription('How many quotes do you want?').setRequired(false))
-        .addBooleanOption(option => option.setName('server').setDescription('Get quotes from this server only? Default: true').setRequired(false)),
+        .addBooleanOption(option => option.setName('server').setDescription('Get quotes from this server only? Default: true').setRequired(false))
+        .setContexts([InteractionContextType.Guild]),
     async execute(interaction: ChatInputCommandInteraction, client: Client) {
         try {
             return new QuoteBuilder().getQuote('/api/v1/quotes/search', 'Recent Quotes', client, interaction);

--- a/src/commands/quotedb_get.ts
+++ b/src/commands/quotedb_get.ts
@@ -11,7 +11,7 @@ export default {
         .setContexts([InteractionContextType.Guild]),
     async execute(interaction: ChatInputCommandInteraction, client: Client) {
         try {
-            return new QuoteBuilder().getQuote('/api/v1/quotes/search', 'Recent Quotes', client, interaction);
+            return await new QuoteBuilder().getQuote('/api/v1/quotes/search', 'Recent Quotes', client, interaction);
         } catch (error) {
             return await buildError(interaction, error);
         }

--- a/src/commands/quotedb_get_random.ts
+++ b/src/commands/quotedb_get_random.ts
@@ -1,9 +1,6 @@
 import { SlashCommandBuilder, Client, ChatInputCommandInteraction } from 'discord.js';
 import QuoteBuilder from '../helpers/quoteBuilder.js';
-import CALLER from '../helpers/caller.js';
 import { buildError } from '../helpers/errorBuilder.js';
-
-const API = await import('../config/index.js').then(module => module.apis.quotedb);
 
 export default {
     data: new SlashCommandBuilder()
@@ -12,20 +9,7 @@ export default {
         .addIntegerOption(option => option.setName('number').setDescription('How many quotes do you want?').setRequired(false)),
     async execute(interaction: ChatInputCommandInteraction, client: Client) {
         try {
-            const number = interaction.options.getInteger('number') ?? 1;
-            if (number > 5) return await buildError(interaction, new Error("You can only request up to 5 quotes at a time."));
-
-            const response = await CALLER.get(
-                API.url,
-                `/api/v1/quotes/random/user/${API.user_id}`,
-                `max_quotes=${number}`,
-                { 'Content-Type': 'application/json', 'Authorization': `Bearer ${API.apikey}` }
-            );
-            if (response?.quotes?.length === 0) return await buildError(interaction, new Error("No quotes found."));
-            return new QuoteBuilder()
-                .setTitle('Random Quotes')
-                .addQuotes(response.quotes)
-                .build(client);
+            return new QuoteBuilder().getQuote('/api/v1/quotes/random', 'Random Quotes', client, interaction);
         } catch (error) {
             return await buildError(interaction, error);
         }

--- a/src/commands/quotedb_get_random.ts
+++ b/src/commands/quotedb_get_random.ts
@@ -11,7 +11,7 @@ export default {
         .setContexts([InteractionContextType.Guild]),
     async execute(interaction: ChatInputCommandInteraction, client: Client) {
         try {
-            return new QuoteBuilder().getQuote('/api/v1/quotes/random', 'Random Quotes', client, interaction);
+            return await new QuoteBuilder().getQuote('/api/v1/quotes/random', 'Random Quotes', client, interaction);
         } catch (error) {
             return await buildError(interaction, error);
         }

--- a/src/commands/quotedb_get_random.ts
+++ b/src/commands/quotedb_get_random.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, Client, ChatInputCommandInteraction } from 'discord.js';
+import { SlashCommandBuilder, Client, ChatInputCommandInteraction, InteractionContextType } from 'discord.js';
 import QuoteBuilder from '../helpers/quoteBuilder.js';
 import { buildError } from '../helpers/errorBuilder.js';
 
@@ -6,7 +6,9 @@ export default {
     data: new SlashCommandBuilder()
         .setName('random_quotes')
         .setDescription('Get up to 5 random quotes!')
-        .addIntegerOption(option => option.setName('number').setDescription('How many quotes do you want?').setRequired(false)),
+        .addIntegerOption(option => option.setName('number').setDescription('How many quotes do you want?').setRequired(false))
+        .addBooleanOption(option => option.setName('server').setDescription('Get quotes from this server only? Default: true').setRequired(false))
+        .setContexts([InteractionContextType.Guild]),
     async execute(interaction: ChatInputCommandInteraction, client: Client) {
         try {
             return new QuoteBuilder().getQuote('/api/v1/quotes/random', 'Random Quotes', client, interaction);

--- a/src/helpers/quoteBuilder.ts
+++ b/src/helpers/quoteBuilder.ts
@@ -1,5 +1,10 @@
-import { EmbedBuilder, Colors } from 'discord.js';
+import { EmbedBuilder, Colors, ChatInputCommandInteraction, Client } from 'discord.js';
 import type { ExtendedClient } from '../helpers/interfaces.ts';
+import { buildError } from '../helpers/errorBuilder.js';
+import { apis } from '../config/index.js';
+import CALLER from '../helpers/caller.js';
+
+const API = apis.quotedb;
 
 export default class QuoteBuilder {
     private embed: EmbedBuilder;
@@ -27,5 +32,20 @@ export default class QuoteBuilder {
         this.embed.setTimestamp();
         this.embed.setColor(Colors.Purple);
         return { embeds: [this.embed] };
+    }
+
+    async getQuote(basePath: string, title: string, client: Client, interaction: ChatInputCommandInteraction) {
+        const number = interaction.options.getInteger('number') ?? 1;
+        const server = interaction.options.getBoolean('server');
+        if (number > 5) return await buildError(interaction, new Error("You can only request up to 5 quotes at a time."));
+        const extension = server === null || server === true ? `server/${interaction?.guild?.id}` : `user/${API.user_id}`
+        const response = await CALLER.get(
+            API.url,
+            `${basePath}/${extension}`,
+            `max_quotes=${number}`,
+            { 'Content-Type': 'application/json', 'Authorization': `Bearer ${API.apikey}` },
+        );
+        if (response?.quotes?.length === 0) return await buildError(interaction, new Error("No quotes found."));
+        return this.setTitle(title).addQuotes(response.quotes).build(client);
     }
 }

--- a/tests/commands/quotedb_get.test.ts
+++ b/tests/commands/quotedb_get.test.ts
@@ -173,4 +173,16 @@ describe('quotedb_get command execution', () => {
 
     await expect(quotedbGetCommand.execute(mockInteraction, mockClient)).rejects.toThrow('API Error');
   });
+
+  test('should handle errors from QuoteBuilder constructor', async () => {
+    const mockError = new Error('Constructor Error');
+    mockQuoteBuilder.mockImplementationOnce(() => {
+      throw mockError;
+    });
+
+    const result = await quotedbGetCommand.execute(mockInteraction, mockClient);
+
+    expect(mockBuildError).toHaveBeenCalledWith(mockInteraction, mockError);
+    expect(result).toBe('Mocked Error Embed');
+  });
 });

--- a/tests/commands/quotedb_get.test.ts
+++ b/tests/commands/quotedb_get.test.ts
@@ -171,7 +171,10 @@ describe('quotedb_get command execution', () => {
     const mockError = new Error('API Error');
     mockGetQuote.mockRejectedValueOnce(mockError);
 
-    await expect(quotedbGetCommand.execute(mockInteraction, mockClient)).rejects.toThrow('API Error');
+    const result = await quotedbGetCommand.execute(mockInteraction, mockClient);
+
+    expect(mockBuildError).toHaveBeenCalledWith(mockInteraction, mockError);
+    expect(result).toBe('Mocked Error Embed');
   });
 
   test('should handle errors from QuoteBuilder constructor', async () => {

--- a/tests/commands/quotedb_get_random.test.ts
+++ b/tests/commands/quotedb_get_random.test.ts
@@ -171,7 +171,10 @@ describe('quotedb_get_random command execution', () => {
     const mockError = new Error('API Error');
     mockGetQuote.mockRejectedValueOnce(mockError);
 
-    await expect(quotedbGetRandomCommand.execute(mockInteraction, mockClient)).rejects.toThrow('API Error');
+    const result = await quotedbGetRandomCommand.execute(mockInteraction, mockClient);
+
+    expect(mockBuildError).toHaveBeenCalledWith(mockInteraction, mockError);
+    expect(result).toBe('Mocked Error Embed');
   });
 
   test('should handle errors from QuoteBuilder constructor', async () => {

--- a/tests/commands/quotedb_get_random.test.ts
+++ b/tests/commands/quotedb_get_random.test.ts
@@ -16,13 +16,9 @@ jest.unstable_mockModule('../../src/config/index.js', () => ({
 }));
 
 // Mock functions
-const mockSetTitle = jest.fn<any>().mockReturnThis();
-const mockAddQuotes = jest.fn<any>().mockReturnThis();
-const mockBuild = jest.fn<any>().mockReturnValue('Mocked Quote Embed');
+const mockGetQuote = jest.fn<any>();
 const mockQuoteBuilder = jest.fn().mockImplementation(() => ({
-  setTitle: mockSetTitle,
-  addQuotes: mockAddQuotes,
-  build: mockBuild,
+  getQuote: mockGetQuote,
 }));
 
 const mockCallerGet = jest.fn<() => Promise<any>>();
@@ -74,6 +70,10 @@ describe('quotedb_get_random command execution', () => {
   const mockInteraction = {
     options: {
       getInteger: jest.fn(),
+      getBoolean: jest.fn(),
+    },
+    guild: {
+      id: 'mock_server_id',
     },
     reply: jest.fn(),
   } as unknown as ChatInputCommandInteraction<CacheType>;
@@ -99,93 +99,78 @@ describe('quotedb_get_random command execution', () => {
 
   test('should return a single random quote by default', async () => {
     (mockInteraction.options.getInteger as jest.Mock).mockReturnValueOnce(null);
-    mockCallerGet.mockResolvedValueOnce({
-      quotes: [{
-        quote: 'Random Quote 1',
-        author: 'Author 1',
-      }],
-    });
+    (mockInteraction.options.getBoolean as jest.Mock).mockReturnValueOnce(null);
+    mockGetQuote.mockResolvedValueOnce('Mocked Quote Embed');
 
     const result = await quotedbGetRandomCommand.execute(mockInteraction, mockClient);
 
-    expect(mockCallerGet).toHaveBeenCalledWith(
-      'https://quotes.elmu.dev',
-      '/api/v1/quotes/random/user/mock_user_id',
-      'max_quotes=1',
-      { 'Content-Type': 'application/json', 'Authorization': 'Bearer mock_api_key' }
-    );
     expect(mockQuoteBuilder).toHaveBeenCalledTimes(1);
-    expect(mockSetTitle).toHaveBeenCalledWith('Random Quotes');
-    expect(mockAddQuotes).toHaveBeenCalledWith([{
-      quote: 'Random Quote 1',
-      author: 'Author 1',
-    }]);
-    expect(mockBuild).toHaveBeenCalledWith(mockClient);
+    expect(mockGetQuote).toHaveBeenCalledWith(
+      '/api/v1/quotes/random',
+      'Random Quotes',
+      mockClient,
+      mockInteraction
+    );
     expect(result).toBe('Mocked Quote Embed');
   });
 
   test('should return the specified number of random quotes', async () => {
     (mockInteraction.options.getInteger as jest.Mock).mockReturnValueOnce(3);
-    mockCallerGet.mockResolvedValueOnce({
-      quotes: [
-        { quote: 'Random Quote 1', author: 'Author 1' },
-        { quote: 'Random Quote 2', author: 'Author 2' },
-        { quote: 'Random Quote 3', author: 'Author 3' },
-      ],
-    });
+    (mockInteraction.options.getBoolean as jest.Mock).mockReturnValueOnce(null);
+    mockGetQuote.mockResolvedValueOnce('Mocked Quote Embed');
 
     const result = await quotedbGetRandomCommand.execute(mockInteraction, mockClient);
 
-    expect(mockCallerGet).toHaveBeenCalledWith(
-      'https://quotes.elmu.dev',
-      '/api/v1/quotes/random/user/mock_user_id',
-      'max_quotes=3',
-      { 'Content-Type': 'application/json', 'Authorization': 'Bearer mock_api_key' }
-    );
     expect(mockQuoteBuilder).toHaveBeenCalledTimes(1);
-    expect(mockAddQuotes).toHaveBeenCalledWith([
-      { quote: 'Random Quote 1', author: 'Author 1' },
-      { quote: 'Random Quote 2', author: 'Author 2' },
-      { quote: 'Random Quote 3', author: 'Author 3' },
-    ]);
+    expect(mockGetQuote).toHaveBeenCalledWith(
+      '/api/v1/quotes/random',
+      'Random Quotes',
+      mockClient,
+      mockInteraction
+    );
     expect(result).toBe('Mocked Quote Embed');
   });
 
   test('should return an error if more than 5 quotes are requested', async () => {
     (mockInteraction.options.getInteger as jest.Mock).mockReturnValueOnce(6);
+    (mockInteraction.options.getBoolean as jest.Mock).mockReturnValueOnce(null);
+    mockGetQuote.mockResolvedValueOnce('Mocked Error Embed');
 
-    await quotedbGetRandomCommand.execute(mockInteraction, mockClient);
+    const result = await quotedbGetRandomCommand.execute(mockInteraction, mockClient);
 
-    expect(mockBuildError).toHaveBeenCalledWith(
-      mockInteraction,
-      new Error("You can only request up to 5 quotes at a time.")
+    expect(mockQuoteBuilder).toHaveBeenCalledTimes(1);
+    expect(mockGetQuote).toHaveBeenCalledWith(
+      '/api/v1/quotes/random',
+      'Random Quotes',
+      mockClient,
+      mockInteraction
     );
-    expect(mockCallerGet).not.toHaveBeenCalled();
+    expect(result).toBe('Mocked Error Embed');
   });
 
   test('should return an empty quote embed if no quotes are found', async () => {
     (mockInteraction.options.getInteger as jest.Mock).mockReturnValueOnce(1);
-    mockCallerGet.mockResolvedValueOnce({ quotes: [] });
+    (mockInteraction.options.getBoolean as jest.Mock).mockReturnValueOnce(null);
+    mockGetQuote.mockResolvedValueOnce('Mocked Error Embed');
 
     const result = await quotedbGetRandomCommand.execute(mockInteraction, mockClient);
 
-    expect(mockBuildError).toHaveBeenCalledWith(
-      mockInteraction,
-      expect.objectContaining({ message: "No quotes found." })
+    expect(mockQuoteBuilder).toHaveBeenCalledTimes(1);
+    expect(mockGetQuote).toHaveBeenCalledWith(
+      '/api/v1/quotes/random',
+      'Random Quotes',
+      mockClient,
+      mockInteraction
     );
     expect(result).toBe('Mocked Error Embed');
   });
 
   test('should handle API errors', async () => {
     (mockInteraction.options.getInteger as jest.Mock).mockReturnValueOnce(1);
+    (mockInteraction.options.getBoolean as jest.Mock).mockReturnValueOnce(null);
     const mockError = new Error('API Error');
-    mockCallerGet.mockRejectedValueOnce(mockError);
+    mockGetQuote.mockRejectedValueOnce(mockError);
 
-    await quotedbGetRandomCommand.execute(mockInteraction, mockClient);
-
-    expect(mockBuildError).toHaveBeenCalledWith(
-      mockInteraction,
-      mockError
-    );
+    await expect(quotedbGetRandomCommand.execute(mockInteraction, mockClient)).rejects.toThrow('API Error');
   });
 });

--- a/tests/commands/quotedb_get_random.test.ts
+++ b/tests/commands/quotedb_get_random.test.ts
@@ -173,4 +173,16 @@ describe('quotedb_get_random command execution', () => {
 
     await expect(quotedbGetRandomCommand.execute(mockInteraction, mockClient)).rejects.toThrow('API Error');
   });
+
+  test('should handle errors from QuoteBuilder constructor', async () => {
+    const mockError = new Error('Constructor Error');
+    mockQuoteBuilder.mockImplementationOnce(() => {
+      throw mockError;
+    });
+
+    const result = await quotedbGetRandomCommand.execute(mockInteraction, mockClient);
+
+    expect(mockBuildError).toHaveBeenCalledWith(mockInteraction, mockError);
+    expect(result).toBe('Mocked Error Embed');
+  });
 });


### PR DESCRIPTION
Dependant on https://github.com/Elmuti/quotedb/pull/25 to be merged and subject to change if Elmu decides to do a different way
Send server information as part of POST request
add an option to use get methods with a boolean to specify server-level quotes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a server option to quote commands so users can scope queries to their guild.

* **Improvements**
  * Quote creation now tags quotes with the server where they were added for guild-specific management.
  * Quote retrieval consolidated into a single retrieval flow with clearer limits (max 5) and improved error messages when no results are found.

* **Tests**
  * Updated and expanded tests to cover new retrieval flow, server/user contexts and error conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->