### PR TITLE
Add @everyone ping to live notification

### DIFF
--- a/src/commands/naniko.ts
+++ b/src/commands/naniko.ts
@@ -157,7 +157,11 @@ export default class TikTokLiveNotifier {
             }
 
             this.#card!.setTimestamp();
-            await channel.send({ embeds: [this.#card!] });
+            await channel.send({
+                content: '@everyone',
+                embeds: [this.#card!],
+                allowedMentions: { parse: ['everyone'] }
+            });
         } catch (err) {
             this.#logger!.log(`Error sending to channel ${channelId}: ${err instanceof Error ? err.message : String(err)}`);
         }

--- a/tests/commands/naniko.test.ts
+++ b/tests/commands/naniko.test.ts
@@ -659,6 +659,34 @@ describe('TikTokLiveNotifier', () => {
             expect(mockChannel.send).toHaveBeenCalledTimes(2);
         });
 
+        test('should send @everyone ping with notification', async () => {
+            process.env.TIKTOK_LIVE_CHANNEL_IDS = '123456789';
+
+            server.use(
+                http.get('https://www.tiktok.com/@pokenonii', () => {
+                    return HttpResponse.text(LIVE_PROFILE_HTML);
+                })
+            );
+
+            const mockChannel = {
+                isTextBased: jest.fn(() => true),
+                send: jest.fn<() => Promise<any>>().mockResolvedValue({} as any),
+            };
+
+            (mockClient.channels.fetch as jest.Mock<(id: string) => Promise<any>>).mockResolvedValue(mockChannel as any);
+
+            notifier = new TikTokLiveNotifier(mockClient, mockLogger);
+            const callback = scheduledCallbacks[scheduledCallbacks.length - 1];
+
+            await callback();
+            await new Promise(resolve => setImmediate(resolve));
+
+            expect(mockChannel.send).toHaveBeenCalledWith(expect.objectContaining({
+                content: '@everyone',
+                allowedMentions: { parse: ['everyone'] },
+            }));
+        });
+
         test('should log error when no channel IDs configured', async () => {
             delete process.env.TIKTOK_LIVE_CHANNEL_IDS;
 


### PR DESCRIPTION
## Summary
- Add `@everyone` ping to the TikTok live notification, with `allowedMentions` to authorize the mention
- Add test verifying the ping content and allowedMentions are included in the send call

## Test plan
- [x] All 325 tests pass
- [x] Verify live notification pings @everyone in the configured channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)