### PR TITLE
ci: only apply patch label to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    labels:
-      - "patch"
+    labels: []

--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -1,0 +1,24 @@
+name: Auto-label Dependabot PRs
+
+# Dependabot auto-applies major/minor/patch labels when those labels exist in the
+# repo, regardless of dependabot.yml's `labels:` setting. We set `labels: []` in
+# dependabot.yml to suppress all default labelling, then this workflow applies a
+# single `patch` label so every Dependabot PR is treated uniformly downstream.
+
+on:
+    pull_request_target:
+        types: [opened, reopened]
+
+jobs:
+    label:
+        if: github.actor == 'dependabot[bot]'
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        steps:
+            - name: Apply patch label
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  REPO: ${{ github.repository }}
+              run: gh pr edit "$PR_NUMBER" --add-label patch -R "$REPO"

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -4,7 +4,7 @@ name: PR CI & Test
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, labeled]
     branches: [ main ]
 
 jobs:


### PR DESCRIPTION
## Summary
Stops Dependabot from inheriting `major`/`minor` labels on its PRs (a built-in GitHub behaviour when those labels exist in the repo). All Dependabot PRs will now carry only `patch`, which is a prerequisite for safe Dependabot auto-merge.

## Changes
- `.github/dependabot.yml` — `labels: []` to disable default Dependabot labelling.
- `.github/workflows/dependabot-auto-label.yml` (new) — applies only `patch` to PRs opened by `dependabot[bot]`. Uses `pull_request_target` to obtain `pull-requests: write` without enabling fork-wide writes.
- `.github/workflows/deploy-develop.yml` — adds `labeled` to trigger types so the `Check for Version Label` step re-runs once the auto-label workflow attaches `patch` (avoids open-event race).

## Test plan
- [ ] CI passes on this PR (label check should re-fire when `patch` is attached).
- [ ] Verify after merge: next Dependabot PR has only the `patch` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)