### PR TITLE
ci: actively strip major/minor labels from dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -1,24 +1,29 @@
 name: Auto-label Dependabot PRs
 
-# Dependabot auto-applies major/minor/patch labels when those labels exist in the
-# repo, regardless of dependabot.yml's `labels:` setting. We set `labels: []` in
-# dependabot.yml to suppress all default labelling, then this workflow applies a
-# single `patch` label so every Dependabot PR is treated uniformly downstream.
+# Dependabot auto-applies major/minor/patch labels to PRs based on the detected
+# semver bump whenever those labels exist in the repository. That behaviour is
+# independent of dependabot.yml's `labels:` setting (which only controls custom
+# labels). We therefore actively remove `major` and `minor` labels and ensure
+# only `patch` is set, so all Dependabot PRs are treated as patch-level bumps
+# regardless of the dependency's actual semver change.
 
 on:
     pull_request_target:
-        types: [opened, reopened]
+        types: [opened, reopened, labeled]
 
 jobs:
-    label:
+    enforce-patch-only:
         if: github.actor == 'dependabot[bot]'
         runs-on: ubuntu-latest
         permissions:
             pull-requests: write
         steps:
-            - name: Apply patch label
+            - name: Set patch as the only version label
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   PR_NUMBER: ${{ github.event.pull_request.number }}
                   REPO: ${{ github.repository }}
-              run: gh pr edit "$PR_NUMBER" --add-label patch -R "$REPO"
+              run: |
+                  gh pr edit "$PR_NUMBER" -R "$REPO" --remove-label major || true
+                  gh pr edit "$PR_NUMBER" -R "$REPO" --remove-label minor || true
+                  gh pr edit "$PR_NUMBER" -R "$REPO" --add-label patch


### PR DESCRIPTION
## Summary
The previous attempt set `labels: []` in `dependabot.yml` and added an auto-label workflow that applied `patch`. That did not fully fix the problem because GitHub auto-applies `major`/`minor`/`patch` labels to dependabot PRs whenever those labels exist in the repo — independent of `dependabot.yml`'s `labels:` setting. PRs were ending up with `minor,patch` etc.

This PR extends the auto-label workflow to actively **remove** `major` and `minor` before applying `patch`, and also fires on `labeled` events so it cleans up labels Dependabot adds shortly after PR creation.

## Changes
- `.github/workflows/dependabot-auto-label.yml` — also triggers on `labeled`; removes `major` and `minor` before adding `patch`.
- (Quote only) `.github/workflows/deploy-develop-dependabot.yml` — revert the `labeled` trigger added previously. That workflow has no label check, so the trigger only spawned parallel smoke-test runs racing on the `bun.lock` push.

## Test plan
- [ ] CI passes on this PR.
- [ ] Verify after merge: next Dependabot PR has only the `patch` label (not `minor` or `major`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)