### PR TITLE
fix(build): move to better-sqlite3 v13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/*
 data/*
 logs/*
 test-results/*
+build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM node:24-slim AS builder
+# Not -slim: better-sqlite3 v13 relies on npm's implicit `node-gyp rebuild`,
+# which needs Python/make/g++ to configure even though its binding.gyp compiles
+# nothing when a prebuilt binary ships with the package. Builder stage only —
+# the release stage below is still distroless.
+FROM node:24 AS builder
 
 WORKDIR /app
 
@@ -28,7 +32,7 @@ COPY --from=builder /app/dist /app/dist
 COPY --from=builder /app/logs /app/logs
 COPY --from=builder /app/data /app/data
 COPY --from=builder /app/package.json /app/package.json
-COPY --from=builder /app/node_modules/better-sqlite3/build/Release/better_sqlite3.node /app/build/Release/better_sqlite3.node
+COPY --from=builder /app/build /app/build
 
 ENV NODE_ENV=production
 

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -47,11 +47,11 @@ const buildOptions = {
 // better-sqlite3's loader resolves relative to its own __dirname, which esbuild
 // collapses into the bundle's directory.
 function copyNativeBindings() {
-    const sqlitePath = findNativeBinding();
+    const sqlitePath = `node_modules/better-sqlite3/prebuilds/${bindingTarget()}.node`;
     const destDir = 'build/Release';
 
-    if (!sqlitePath) {
-        throw new Error(`Native binding not found for better-sqlite3 (${bindingTarget()})`);
+    if (!existsSync(sqlitePath)) {
+        throw new Error(`Native binding not found: ${sqlitePath}`);
     }
 
     try {
@@ -67,15 +67,7 @@ function copyNativeBindings() {
 }
 
 // better-sqlite3 v13 dropped prebuild-install and ships prebuilt binaries in the
-// package itself; v12 and earlier downloaded or compiled build/Release at install
-// time. Support both so the build works either side of the version bump.
-function findNativeBinding() {
-    return [
-        `node_modules/better-sqlite3/prebuilds/${bindingTarget()}.node`,
-        'node_modules/better-sqlite3/build/Release/better_sqlite3.node',
-    ].find(existsSync);
-}
-
+// package itself, keyed by platform and arch.
 function bindingTarget() {
     const isLinuxMusl = process.platform === 'linux' && !process.report.getReport().header.glibcVersionRuntime;
 

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -42,13 +42,16 @@ const buildOptions = {
     },
 };
 
-// Copy better-sqlite3 native bindings after build
-async function copyNativeBindings() {
-    const sqlitePath = 'node_modules/better-sqlite3/build/Release/better_sqlite3.node';
-    const destDir = 'dist/build/Release';
+// Copy better-sqlite3 native bindings after build. The destination is the path
+// the bundled output probes at runtime — <bundle dir>/../build/Release — since
+// better-sqlite3's loader resolves relative to its own __dirname, which esbuild
+// collapses into the bundle's directory.
+function copyNativeBindings() {
+    const sqlitePath = findNativeBinding();
+    const destDir = 'build/Release';
 
-    if (!existsSync(sqlitePath)) {
-        throw new Error(`Native binding not found: ${sqlitePath}`);
+    if (!sqlitePath) {
+        throw new Error(`Native binding not found for better-sqlite3 (${bindingTarget()})`);
     }
 
     try {
@@ -57,10 +60,26 @@ async function copyNativeBindings() {
         }
 
         copyFileSync(sqlitePath, join(destDir, 'better_sqlite3.node'));
-        console.log('✓ Copied native SQLite binding');
+        console.log(`✓ Copied native SQLite binding from ${sqlitePath}`);
     } catch (error) {
         throw new Error(`Error copying native bindings: ${error.message}`);
     }
+}
+
+// better-sqlite3 v13 dropped prebuild-install and ships prebuilt binaries in the
+// package itself; v12 and earlier downloaded or compiled build/Release at install
+// time. Support both so the build works either side of the version bump.
+function findNativeBinding() {
+    return [
+        `node_modules/better-sqlite3/prebuilds/${bindingTarget()}.node`,
+        'node_modules/better-sqlite3/build/Release/better_sqlite3.node',
+    ].find(existsSync);
+}
+
+function bindingTarget() {
+    const isLinuxMusl = process.platform === 'linux' && !process.report.getReport().header.glibcVersionRuntime;
+
+    return `${isLinuxMusl ? 'linuxmusl' : process.platform}-${process.arch}`;
 }
 
 if (isWatch) {
@@ -69,6 +88,6 @@ if (isWatch) {
     console.log('Watching for changes...');
 } else {
     await esbuild.build(buildOptions);
-    await copyNativeBindings();
+    copyNativeBindings();
     console.log('Build complete!');
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "bongbot",
             "version": "0.1.0",
             "dependencies": {
-                "@pookiesoft/bongbot-core": "^1.6.43",
+                "@pookiesoft/bongbot-core": "^1.6.31",
                 "@pookiesoft/bongbot-ptero": "^1.4.11",
                 "@pookiesoft/bongbot-quote": "^2.1.42"
             },
@@ -17,7 +17,7 @@
                 "@types/better-sqlite3": "^7.6.13",
                 "@types/jest": "^30.0.0",
                 "@types/node-schedule": "^2.1.8",
-                "better-sqlite3": "^13.0.3",
+                "better-sqlite3": "^12.11.1",
                 "cross-env": "^10.1.0",
                 "discord.js": "^14.27.0",
                 "esbuild": "^0.28.1",
@@ -64,7 +64,6 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -1781,12 +1780,12 @@
             }
         },
         "node_modules/@pookiesoft/bongbot-core": {
-            "version": "1.6.43",
-            "resolved": "https://npm.pkg.github.com/download/@pookiesoft/bongbot-core/1.6.43/1629b3f4e54f2da85908015fce277bcb45d49405",
-            "integrity": "sha512-RPqubh2JFULrxxQnkoC8Vam2PPGcLwDCVPB/rftK6TbpPQhgF9NSu40g9YSnU7xDrJ7WQ81kVVyEtdsvw3lpYQ==",
+            "version": "1.6.31",
+            "resolved": "https://npm.pkg.github.com/download/@pookiesoft/bongbot-core/1.6.31/4e2b3a41a7ea1f87d96c25be74921a8841f2b100",
+            "integrity": "sha512-30P6NUqYQzn9Y9T3UH+sWHY6SamrgjP9XMCG187jvk7RqtTdGrU0bLdkWAvpL/UdMDxpgGklzfqqc211Ixjj1w==",
             "hasInstallScript": true,
             "dependencies": {
-                "better-sqlite3": "^13.0.2",
+                "better-sqlite3": "^12.11.1",
                 "ipaddr.js": "^2.4.0",
                 "source-map-support": "^0.5.21"
             },
@@ -2018,7 +2017,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
             "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~7.18.0"
             }
@@ -2590,6 +2588,26 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/baseline-browser-mapping": {
             "version": "2.10.12",
             "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
@@ -2604,16 +2622,37 @@
             }
         },
         "node_modules/better-sqlite3": {
-            "version": "13.0.3",
-            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
-            "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+            "version": "12.11.1",
+            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+            "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
+            "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "node-addon-api": "^8.0.0"
+                "bindings": "^1.5.0",
+                "prebuild-install": "^7.1.1"
             },
             "engines": {
-                "node": ">=22"
+                "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+            }
+        },
+        "node_modules/bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "license": "MIT",
+            "dependencies": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
+        "node_modules/bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "license": "MIT",
+            "dependencies": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
             }
         },
         "node_modules/brace-expansion": {
@@ -2659,7 +2698,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -2695,6 +2733,30 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "node-int64": "^0.4.0"
+            }
+        },
+        "node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
             }
         },
         "node_modules/buffer-from": {
@@ -2770,6 +2832,12 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+            "license": "ISC"
         },
         "node_modules/ci-info": {
             "version": "4.4.0",
@@ -3019,6 +3087,21 @@
                 }
             }
         },
+        "node_modules/decompress-response": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-response": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/dedent": {
             "version": "1.7.2",
             "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -3034,6 +3117,15 @@
                 }
             }
         },
+        "node_modules/deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
         "node_modules/deepmerge": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -3042,6 +3134,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/detect-newline": {
@@ -3078,7 +3179,6 @@
             "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.27.0.tgz",
             "integrity": "sha512-qHbFlFG2N7y3LjPySYsL6A1+BnX6bkTVgo842EX0CqVPk/KTMwZkojPHEXKsQUpWZNyz5BISNHK1cPpQw0+m4A==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@discordjs/builders": "^1.14.1",
                 "@discordjs/collection": "1.5.3",
@@ -3134,6 +3234,15 @@
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/end-of-stream": {
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+            "license": "MIT",
+            "dependencies": {
+                "once": "^1.4.0"
+            }
         },
         "node_modules/error-ex": {
             "version": "1.3.4",
@@ -3262,6 +3371,15 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/expand-template": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+            "license": "(MIT OR WTFPL)",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/expect": {
             "version": "30.4.1",
             "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
@@ -3330,6 +3448,12 @@
                 "bser": "2.1.1"
             }
         },
+        "node_modules/file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "license": "MIT"
+        },
         "node_modules/fill-range": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3373,6 +3497,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
+        },
+        "node_modules/fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+            "license": "MIT"
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -3448,6 +3578,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/github-from-package": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+            "license": "MIT"
         },
         "node_modules/glob": {
             "version": "10.5.0",
@@ -3561,6 +3697,26 @@
                 "node": ">=10.17.0"
             }
         },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
         "node_modules/import-local": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -3607,7 +3763,12 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "license": "ISC"
         },
         "node_modules/ipaddr.js": {
@@ -3805,7 +3966,6 @@
             "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "30.4.2",
                 "@jest/types": "30.4.1",
@@ -4679,6 +4839,18 @@
                 "node": ">=6"
             }
         },
+        "node_modules/mimic-response": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/minimatch": {
             "version": "9.0.9",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -4699,7 +4871,6 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4727,6 +4898,12 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+            "license": "MIT"
         },
         "node_modules/ms": {
             "version": "2.1.3",
@@ -4813,6 +4990,12 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
+        "node_modules/napi-build-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+            "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+            "license": "MIT"
+        },
         "node_modules/napi-postinstall": {
             "version": "0.3.4",
             "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
@@ -4843,13 +5026,28 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/node-addon-api": {
-            "version": "8.9.2",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
-            "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
+        "node_modules/node-abi": {
+            "version": "3.89.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+            "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
             "license": "MIT",
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
             "engines": {
-                "node": "^18 || ^20 || >= 21"
+                "node": ">=10"
+            }
+        },
+        "node_modules/node-abi/node_modules/semver": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/node-int64": {
@@ -4908,7 +5106,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
@@ -5129,6 +5326,33 @@
                 "node": ">=8"
             }
         },
+        "node_modules/prebuild-install": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+            "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+            "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+            "license": "MIT",
+            "dependencies": {
+                "detect-libc": "^2.0.0",
+                "expand-template": "^2.0.3",
+                "github-from-package": "0.0.0",
+                "minimist": "^1.2.3",
+                "mkdirp-classic": "^0.5.3",
+                "napi-build-utils": "^2.0.0",
+                "node-abi": "^3.3.0",
+                "pump": "^3.0.0",
+                "rc": "^1.2.7",
+                "simple-get": "^4.0.0",
+                "tar-fs": "^2.0.0",
+                "tunnel-agent": "^0.6.0"
+            },
+            "bin": {
+                "prebuild-install": "bin.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/prettier": {
             "version": "3.9.6",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
@@ -5174,6 +5398,16 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/pump": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+            "license": "MIT",
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
         "node_modules/pure-rand": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
@@ -5190,6 +5424,30 @@
                 }
             ],
             "license": "MIT"
+        },
+        "node_modules/rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+            "dependencies": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "bin": {
+                "rc": "cli.js"
+            }
+        },
+        "node_modules/rc/node_modules/strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/react-is": {
             "version": "18.3.1",
@@ -5213,6 +5471,20 @@
             "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
@@ -5285,6 +5557,26 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/semver": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -5336,6 +5628,51 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/simple-concat": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/simple-get": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "decompress-response": "^6.0.0",
+                "once": "^1.3.1",
+                "simple-concat": "^1.0.0"
             }
         },
         "node_modules/slash": {
@@ -5410,6 +5747,15 @@
             "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
         },
         "node_modules/string-length": {
             "version": "4.0.2",
@@ -5638,6 +5984,34 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/tar-fs": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+            "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.1.4"
+            }
+        },
+        "node_modules/tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "license": "MIT",
+            "dependencies": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/test-exclude": {
@@ -6088,7 +6462,6 @@
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -6133,6 +6506,18 @@
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
         },
+        "node_modules/tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/type-detect": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -6162,7 +6547,6 @@
             "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -6275,6 +6659,12 @@
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
             }
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "license": "MIT"
         },
         "node_modules/uuid": {
             "version": "14.0.0",
@@ -6444,7 +6834,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/write-file-atomic": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "bongbot",
             "version": "0.1.0",
             "dependencies": {
-                "@pookiesoft/bongbot-core": "^1.6.31",
+                "@pookiesoft/bongbot-core": "^1.6.43",
                 "@pookiesoft/bongbot-ptero": "^1.4.11",
                 "@pookiesoft/bongbot-quote": "^2.1.42"
             },
@@ -17,7 +17,7 @@
                 "@types/better-sqlite3": "^7.6.13",
                 "@types/jest": "^30.0.0",
                 "@types/node-schedule": "^2.1.8",
-                "better-sqlite3": "^12.11.1",
+                "better-sqlite3": "^13.0.3",
                 "cross-env": "^10.1.0",
                 "discord.js": "^14.27.0",
                 "esbuild": "^0.28.1",
@@ -64,6 +64,7 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -1780,12 +1781,12 @@
             }
         },
         "node_modules/@pookiesoft/bongbot-core": {
-            "version": "1.6.31",
-            "resolved": "https://npm.pkg.github.com/download/@pookiesoft/bongbot-core/1.6.31/4e2b3a41a7ea1f87d96c25be74921a8841f2b100",
-            "integrity": "sha512-30P6NUqYQzn9Y9T3UH+sWHY6SamrgjP9XMCG187jvk7RqtTdGrU0bLdkWAvpL/UdMDxpgGklzfqqc211Ixjj1w==",
+            "version": "1.6.43",
+            "resolved": "https://npm.pkg.github.com/download/@pookiesoft/bongbot-core/1.6.43/1629b3f4e54f2da85908015fce277bcb45d49405",
+            "integrity": "sha512-RPqubh2JFULrxxQnkoC8Vam2PPGcLwDCVPB/rftK6TbpPQhgF9NSu40g9YSnU7xDrJ7WQ81kVVyEtdsvw3lpYQ==",
             "hasInstallScript": true,
             "dependencies": {
-                "better-sqlite3": "^12.11.1",
+                "better-sqlite3": "^13.0.2",
                 "ipaddr.js": "^2.4.0",
                 "source-map-support": "^0.5.21"
             },
@@ -2017,6 +2018,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
             "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~7.18.0"
             }
@@ -2588,26 +2590,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/base64-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/baseline-browser-mapping": {
             "version": "2.10.12",
             "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
@@ -2622,37 +2604,16 @@
             }
         },
         "node_modules/better-sqlite3": {
-            "version": "12.11.1",
-            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
-            "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
-            "hasInstallScript": true,
+            "version": "13.0.3",
+            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
+            "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "bindings": "^1.5.0",
-                "prebuild-install": "^7.1.1"
+                "node-addon-api": "^8.0.0"
             },
             "engines": {
-                "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
-            }
-        },
-        "node_modules/bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "license": "MIT",
-            "dependencies": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
-        "node_modules/bl": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "license": "MIT",
-            "dependencies": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
+                "node": ">=22"
             }
         },
         "node_modules/brace-expansion": {
@@ -2698,6 +2659,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -2733,30 +2695,6 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "node-int64": "^0.4.0"
-            }
-        },
-        "node_modules/buffer": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
             }
         },
         "node_modules/buffer-from": {
@@ -2832,12 +2770,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "license": "ISC"
         },
         "node_modules/ci-info": {
             "version": "4.4.0",
@@ -3087,21 +3019,6 @@
                 }
             }
         },
-        "node_modules/decompress-response": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-            "license": "MIT",
-            "dependencies": {
-                "mimic-response": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/dedent": {
             "version": "1.7.2",
             "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -3117,15 +3034,6 @@
                 }
             }
         },
-        "node_modules/deep-extend": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
         "node_modules/deepmerge": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -3134,15 +3042,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/detect-libc": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/detect-newline": {
@@ -3179,6 +3078,7 @@
             "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.27.0.tgz",
             "integrity": "sha512-qHbFlFG2N7y3LjPySYsL6A1+BnX6bkTVgo842EX0CqVPk/KTMwZkojPHEXKsQUpWZNyz5BISNHK1cPpQw0+m4A==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@discordjs/builders": "^1.14.1",
                 "@discordjs/collection": "1.5.3",
@@ -3234,15 +3134,6 @@
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/end-of-stream": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-            "license": "MIT",
-            "dependencies": {
-                "once": "^1.4.0"
-            }
         },
         "node_modules/error-ex": {
             "version": "1.3.4",
@@ -3371,15 +3262,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/expand-template": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "license": "(MIT OR WTFPL)",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/expect": {
             "version": "30.4.1",
             "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
@@ -3448,12 +3330,6 @@
                 "bser": "2.1.1"
             }
         },
-        "node_modules/file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "license": "MIT"
-        },
         "node_modules/fill-range": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3497,12 +3373,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
-        },
-        "node_modules/fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "license": "MIT"
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -3578,12 +3448,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/github-from-package": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-            "license": "MIT"
         },
         "node_modules/glob": {
             "version": "10.5.0",
@@ -3697,26 +3561,6 @@
                 "node": ">=10.17.0"
             }
         },
-        "node_modules/ieee754": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "BSD-3-Clause"
-        },
         "node_modules/import-local": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -3763,12 +3607,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "license": "ISC"
-        },
-        "node_modules/ini": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/ipaddr.js": {
@@ -3966,6 +3805,7 @@
             "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/core": "30.4.2",
                 "@jest/types": "30.4.1",
@@ -4839,18 +4679,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/mimic-response": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/minimatch": {
             "version": "9.0.9",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -4871,6 +4699,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4898,12 +4727,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "license": "MIT"
         },
         "node_modules/ms": {
             "version": "2.1.3",
@@ -4990,12 +4813,6 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/napi-build-utils": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-            "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-            "license": "MIT"
-        },
         "node_modules/napi-postinstall": {
             "version": "0.3.4",
             "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
@@ -5026,28 +4843,13 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/node-abi": {
-            "version": "3.89.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-            "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+        "node_modules/node-addon-api": {
+            "version": "8.9.2",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+            "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
             "license": "MIT",
-            "dependencies": {
-                "semver": "^7.3.5"
-            },
             "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/node-abi/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
+                "node": "^18 || ^20 || >= 21"
             }
         },
         "node_modules/node-int64": {
@@ -5106,6 +4908,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
@@ -5326,33 +5129,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/prebuild-install": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-            "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-            "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-            "license": "MIT",
-            "dependencies": {
-                "detect-libc": "^2.0.0",
-                "expand-template": "^2.0.3",
-                "github-from-package": "0.0.0",
-                "minimist": "^1.2.3",
-                "mkdirp-classic": "^0.5.3",
-                "napi-build-utils": "^2.0.0",
-                "node-abi": "^3.3.0",
-                "pump": "^3.0.0",
-                "rc": "^1.2.7",
-                "simple-get": "^4.0.0",
-                "tar-fs": "^2.0.0",
-                "tunnel-agent": "^0.6.0"
-            },
-            "bin": {
-                "prebuild-install": "bin.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/prettier": {
             "version": "3.9.6",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
@@ -5398,16 +5174,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/pump": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-            "license": "MIT",
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
         "node_modules/pure-rand": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
@@ -5424,30 +5190,6 @@
                 }
             ],
             "license": "MIT"
-        },
-        "node_modules/rc": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-            "dependencies": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-            },
-            "bin": {
-                "rc": "cli.js"
-            }
-        },
-        "node_modules/rc/node_modules/strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/react-is": {
             "version": "18.3.1",
@@ -5471,20 +5213,6 @@
             "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
@@ -5557,26 +5285,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/semver": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -5628,51 +5336,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/simple-concat": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
-        "node_modules/simple-get": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "decompress-response": "^6.0.0",
-                "once": "^1.3.1",
-                "simple-concat": "^1.0.0"
             }
         },
         "node_modules/slash": {
@@ -5747,15 +5410,6 @@
             "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/string_decoder": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "~5.2.0"
-            }
         },
         "node_modules/string-length": {
             "version": "4.0.2",
@@ -5984,34 +5638,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/tar-fs": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-            "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-            "license": "MIT",
-            "dependencies": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
-            }
-        },
-        "node_modules/tar-stream": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "license": "MIT",
-            "dependencies": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-            },
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/test-exclude": {
@@ -6462,6 +6088,7 @@
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -6506,18 +6133,6 @@
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
         },
-        "node_modules/tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "safe-buffer": "^5.0.1"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/type-detect": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -6547,6 +6162,7 @@
             "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -6659,12 +6275,6 @@
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
             }
-        },
-        "node_modules/util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "license": "MIT"
         },
         "node_modules/uuid": {
             "version": "14.0.0",
@@ -6834,6 +6444,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --json --coverage --outputFile=report.json --passWithNoTests --silent"
     },
     "dependencies": {
-        "@pookiesoft/bongbot-core": "^1.6.43",
+        "@pookiesoft/bongbot-core": "^1.6.31",
         "@pookiesoft/bongbot-ptero": "^1.4.11",
         "@pookiesoft/bongbot-quote": "^2.1.42"
     },
@@ -19,7 +19,7 @@
         "@types/better-sqlite3": "^7.6.13",
         "@types/jest": "^30.0.0",
         "@types/node-schedule": "^2.1.8",
-        "better-sqlite3": "^13.0.3",
+        "better-sqlite3": "^12.11.1",
         "cross-env": "^10.1.0",
         "discord.js": "^14.27.0",
         "esbuild": "^0.28.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --json --coverage --outputFile=report.json --passWithNoTests --silent"
     },
     "dependencies": {
-        "@pookiesoft/bongbot-core": "^1.6.31",
+        "@pookiesoft/bongbot-core": "^1.6.43",
         "@pookiesoft/bongbot-ptero": "^1.4.11",
         "@pookiesoft/bongbot-quote": "^2.1.42"
     },
@@ -19,7 +19,7 @@
         "@types/better-sqlite3": "^7.6.13",
         "@types/jest": "^30.0.0",
         "@types/node-schedule": "^2.1.8",
-        "better-sqlite3": "^12.11.1",
+        "better-sqlite3": "^13.0.3",
         "cross-env": "^10.1.0",
         "discord.js": "^14.27.0",
         "esbuild": "^0.28.1",
@@ -33,5 +33,11 @@
         "ts-jest-resolver": "^2.0.1",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3"
-    }
+    },
+    "overrides": {
+        "@pookiesoft/bongbot-ptero": {
+            "better-sqlite3": "$better-sqlite3"
+        }
+    },
+    "_overrides_note": "TODO: Remove the bongbot-ptero override once @pookiesoft/bongbot-ptero >=1.4.14 is released with its better-sqlite3 peer range on ^13.0.0. The published 1.4.13 still declares ^12.9.0, which blocks v13 here."
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --json --coverage --outputFile=report.json --passWithNoTests --silent"
     },
     "dependencies": {
-        "@pookiesoft/bongbot-core": "^1.6.31",
+        "@pookiesoft/bongbot-core": "^1.6.43",
         "@pookiesoft/bongbot-ptero": "^1.4.11",
         "@pookiesoft/bongbot-quote": "^2.1.42"
     },
@@ -19,7 +19,7 @@
         "@types/better-sqlite3": "^7.6.13",
         "@types/jest": "^30.0.0",
         "@types/node-schedule": "^2.1.8",
-        "better-sqlite3": "^12.11.1",
+        "better-sqlite3": "^13.0.3",
         "cross-env": "^10.1.0",
         "discord.js": "^14.27.0",
         "esbuild": "^0.28.1",

--- a/package.json
+++ b/package.json
@@ -39,5 +39,5 @@
             "better-sqlite3": "$better-sqlite3"
         }
     },
-    "_overrides_note": "TODO: Remove the bongbot-ptero override once @pookiesoft/bongbot-ptero >=1.4.14 is released with its better-sqlite3 peer range on ^13.0.0. The published 1.4.13 still declares ^12.9.0, which blocks v13 here."
+    "_overrides_note": "TODO: Remove the bongbot-ptero override once a release of @pookiesoft/bongbot-ptero carries its better-sqlite3 peer range on ^13.0.0. The published 1.4.13 still declares ^12.9.0, which blocks v13 here."
 }


### PR DESCRIPTION
## Root cause

**better-sqlite3 v13 changed how the native binary is delivered.**

| | v12.x | v13.x |
|---|---|---|
| install script | `prebuild-install \|\| node-gyp rebuild --release` | none — npm falls back to its **implicit** `node-gyp rebuild` because `binding.gyp` is present |
| deps | `bindings`, `prebuild-install` | `node-addon-api` |
| binary after install | `build/Release/better_sqlite3.node` | `prebuilds/<platform>-<arch>.node`, shipped in the tarball |

`node_modules/better-sqlite3/build/Release/better_sqlite3.node` no longer exists after install. Two things break:

**1. `npm ci` fails in the builder image.** `node:24-slim` has no Python or C++ toolchain, and v13's implicit `node-gyp rebuild` needs them just to *configure* — even though `binding.gyp` compiles nothing when a prebuild is present (`type: none`):

```
npm error path /app/node_modules/better-sqlite3
npm error command sh -c node-gyp rebuild
npm error gyp ERR! find Python
```

That's the failure on [run 30742632184](https://github.com/PookieSoft/BongBot/actions/runs/30742632184) and every other `better-sqlite3` Dependabot PR here.

**2. The hardcoded `build/Release` paths break.** Both `copyNativeBindings()` and the release-stage `COPY` point at a file that no longer exists. The same code took down BongBot-Quote's release workflow ([run 31736066008](https://github.com/PookieSoft/BongBot-Quote/actions/runs/31736066008/job/94568164811)).

## Changes

- **Resolve the native binding from `prebuilds/<platform>-<arch>.node`.**
- **Copy it to `build/Release/better_sqlite3.node` at the project root**, not `dist/build/Release`. That's the path the bundle actually probes: better-sqlite3 resolves relative to its own `__dirname`, which esbuild collapses into the bundle's directory, so the runtime lookup is `<dist>/../build/Release/…`. The Dockerfile now copies that directory rather than reaching into `node_modules` — same final image layout as before.
- **Builder on `node:24` instead of `node:24-slim`** so node-gyp can configure. Builder stage only — the release stage is still distroless and unchanged in size.
- **`better-sqlite3` → `^13.0.3`, `@pookiesoft/bongbot-core` → `^1.6.43`.**

## The resolver conflict, and the bridge

Bumping alone doesn't install — CI caught this:

```
npm error code ERESOLVE
npm error Found: better-sqlite3@13.0.3
npm error   better-sqlite3@"^13.0.2" from @pookiesoft/bongbot-core@1.6.43
npm error Could not resolve dependency:
npm error peer better-sqlite3@"^12.9.0" from @pookiesoft/bongbot-ptero@1.4.11
```

Published `@pookiesoft/bongbot-ptero@1.4.13` declares a `better-sqlite3` **peer** of `^12.9.0`, while `@pookiesoft/bongbot-core@1.6.43` requires `^13.0.2`. Mutually unsatisfiable.

The durable fix is PookieSoft/BongBot-Ptero#60, which moves that peer to `^13.0.0` — but it isn't released yet, and staying on v12 in the meantime means running an unmaintained line that no longer gets security fixes. So this bridges with an npm override:

```json
"overrides": {
    "@pookiesoft/bongbot-ptero": {
        "better-sqlite3": "$better-sqlite3"
    }
}
```

`$better-sqlite3` references this project's own dependency spec rather than a literal version, so the override tracks future Dependabot bumps instead of freezing anything. A `_overrides_note` field records the removal condition, following the `_postinstall_note` convention already used in bongbot-core.

This is safe, not just a resolver silencer: the two majors are API-compatible — only the native binding layout moved — and Ptero#60's CI (157 tests plus a container smoke test) proves its source works against v13.

## Verification

Docker isn't available in the environment this was written in, so the image build is left to this PR's own CI (`build-docker` + `smoke-test`). Locally:

- `npm ci` resolves cleanly with the override, to **exactly one** `better-sqlite3` at 13.0.3 ✅
- Build resolves `prebuilds/darwin-arm64.node` and writes `build/Release/better_sqlite3.node` ✅
- Zero v12 `bindings` path-search strings left in `dist/index.js` ✅
- `npm test` — 325 passed across 39 suites, 100% lines ✅

## Follow-up

Once bongbot-ptero releases with the widened peer, drop the `overrides` block and `_overrides_note`, and bump `@pookiesoft/bongbot-ptero`.

## Related

- PookieSoft/BongBot-Quote#78 — same upstream cause, publish job
- PookieSoft/BongBot-Ptero#60 — the peer-range fix this bridges

🤖 Generated with [Claude Code](https://claude.com/claude-code)